### PR TITLE
Fix bytes_to_point variable mutation

### DIFF
--- a/bip-0328/_xpub.py
+++ b/bip-0328/_xpub.py
@@ -83,8 +83,8 @@ def deserialize_point(b: bytes) -> Point:
 def bytes_to_point(point_bytes: bytes) -> Point:
     header = point_bytes[0]
     if header == 4:
-        x = point_bytes = point_bytes[1:33]
-        y = point_bytes = point_bytes[33:65]
+        x = point_bytes[1:33]
+        y = point_bytes[33:65]
         return (int(binascii.hexlify(x), 16), int(binascii.hexlify(y), 16))
     return deserialize_point(point_bytes)
 


### PR DESCRIPTION
## Summary
- avoid overwriting `point_bytes` when parsing uncompressed points

## Testing
- `python3 -m py_compile bip-0328/_xpub.py`