### PR TITLE
Fix typo in wallet_policies

### DIFF
--- a/bip-0388/wallet_policies.py
+++ b/bip-0388/wallet_policies.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     ]
 
     for desc in descriptors:
-        # Demoes the conversion from a "sane" descriptor to a wallet policy
+        # Demonstrates the conversion from a "sane" descriptor to a wallet policy
         print(f"Descriptor:\n{desc}")
         wp = WalletPolicy.from_descriptor(desc)
         print(f"Policy descriptor template:\n{wp.descriptor_template}")


### PR DESCRIPTION
## Summary
- fix a minor typo in `wallet_policies.py`

## Testing
- `python3 -m py_compile bip-0388/wallet_policies.py`
- `typos` *(fails: command not found)*