### PR TITLE
Add test vector consistency check

### DIFF
--- a/.github/workflows/github-action-checks.yml
+++ b/.github/workflows/github-action-checks.yml
@@ -29,3 +29,11 @@ jobs:
 
       - name: Check spelling
         uses: crate-ci/typos@master
+
+  BIP340-Test-Vectors:
+    name: "BIP340 Test Vector Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run vector consistency check
+        run: python3 bip-0340/check_vectors.py

--- a/bip-0340/check_vectors.py
+++ b/bip-0340/check_vectors.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Simple check script to verify BIP340 test vectors.
+
+This runs ``test-vectors.py`` to regenerate the CSV data and compares the
+result with ``test-vectors.csv``. The script exits with a non-zero status if
+the files differ.
+"""
+
+import subprocess
+import sys
+import difflib
+from pathlib import Path
+
+# Paths relative to repository root
+BASE_DIR = Path(__file__).resolve().parent
+TEST_VECTOR_SCRIPT = BASE_DIR / "test-vectors.py"
+EXPECTED_CSV = BASE_DIR / "test-vectors.csv"
+
+# Run the generator script and capture its CSV output
+result = subprocess.run(
+    [sys.executable, str(TEST_VECTOR_SCRIPT)],
+    capture_output=True,
+    text=True,
+)
+
+if result.returncode != 0:
+    print(result.stdout)
+    print(result.stderr, file=sys.stderr)
+    sys.exit(result.returncode)
+
+# Normalize line endings and strip trailing whitespace
+output = result.stdout.strip().splitlines()
+expected = EXPECTED_CSV.read_text().strip().splitlines()
+
+if output != expected:
+    print("Generated test vectors do not match test-vectors.csv", file=sys.stderr)
+    diff = difflib.unified_diff(
+        expected,
+        output,
+        fromfile="test-vectors.csv",
+        tofile="generated",
+        lineterm="",
+    )
+    for line in diff:
+        print(line)
+    sys.exit(1)
+
+print("Test vectors match." )
+


### PR DESCRIPTION
## Summary
- add a Python test helper to check that BIP340 test vectors have not changed
- run this check in CI

## Testing
- `python3 bip-0340/check_vectors.py`
- `scripts/link-format-chk.sh`
- `scripts/buildtable.pl >/tmp/table.mediawiki`
- `scripts/diffcheck.sh` *(checkout returned to branch after running)*
- `typos` *(failed: command not found)*